### PR TITLE
handoff launch of command to baseimage `/entrypoint.sh`

### DIFF
--- a/rootfs/app-entrypoint.sh
+++ b/rootfs/app-entrypoint.sh
@@ -14,10 +14,7 @@ export MARIADB_PORT=${MARIADB_PORT:-"3306"}
 status=`harpoon inspect redmine`
 if [[ "$status" == *'"lifecycle": "unpacked"'* && "$1" == "harpoon" && "$2" == "start" ]]; then
     harpoon initialize redmine --inputs-file=/inputs.json
-    /entrypoint.sh
     echo "Starting application..."
-else
-    /entrypoint.sh
 fi
 
-exec tini -- "$@"
+exec /entrypoint.sh "$@"


### PR DESCRIPTION
requires `latest` build of https://github.com/bitnami/stacksmith-base for proper launch via `tini`