### PR TITLE
Unify instructions for application persistence in name modules documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ version: '2'
 1. Create a network (if it does not exist):
 
   ```
-  $ docker network create redmine_network
+  $ docker network create redmine
   ```
 
 2. Create a MariaDB container with host volume:
@@ -122,8 +122,9 @@ version: '2'
 3. Run the Redmine container:
 
   ```
-  $ docker run -d -p 80:3000 --name redmine -v /path/to/bitnami/redmine:/bitnami/redmine \
-    --network=redmine_network bitnami/redmine \
+  $ docker run -d --name redmine -p 80:3000 \
+    --net redmine \
+    --volume /path/to/redmine-persistence:/bitnami/redmine \
   bitnami/redmine:latest
   ```
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Then you can access your application at http://your-ip/
 
 If you remove every container and volume all your data will be lost, and the next time you run the image the application will be reinitialized. To avoid this loss of data, you should mount a volume that will persist even after the container is removed. 
 
-For persistence of the Redmine deployment, the above examples define docker volumes namely mariadb_data and redmine_data. The Redmine application state will persist as long as these volumes are not removed.
+For persistence of the Redmine deployment, the above examples define docker volumes namely `mariadb_data` and `redmine_data`. The Redmine application state will persist as long as these volumes are not removed.
 
 If avoid inadvertent removal of these volumes you can [mount host directories as data volumes](https://docs.docker.com/engine/tutorials/dockervolumes/). Alternatively you can make use of volume plugins to host the volume data.
 
@@ -82,7 +82,8 @@ If avoid inadvertent removal of these volumes you can [mount host directories as
 
 ### Mount host directories as data volumes with Docker Compose
 
-This requires a sightly modification from the template previously shown:
+The following `docker-compose.yml` template demonstrates the use of host directories as data volumes.
+
 ```yaml
 version: '2'
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ If you remove every container and volume all your data will be lost, and the nex
 
 For persistence of the Redmine deployment, the above examples define docker volumes namely `mariadb_data` and `redmine_data`. The Redmine application state will persist as long as these volumes are not removed.
 
-If avoid inadvertent removal of these volumes you can [mount host directories as data volumes](https://docs.docker.com/engine/tutorials/dockervolumes/). Alternatively you can make use of volume plugins to host the volume data.
+To avoid inadvertent removal of these volumes you can [mount host directories as data volumes](https://docs.docker.com/engine/tutorials/dockervolumes/). Alternatively you can make use of volume plugins to host the volume data.
 
 > **Note!** If you have already started using your application, follow the steps on [backing](#backing-up-your-application) up to pull the data from your running container down to your host.
 

--- a/README.md
+++ b/README.md
@@ -105,14 +105,14 @@ version: '2'
 1. Create a network (if it does not exist):
 
   ```
-  $ docker network create redmine
+  $ docker network create redmine-tier
   ```
 
 2. Create a MariaDB container with host volume:
 
   ```
   $ docker run -d --name mariadb \
-    --net redmine \
+    --net redmine-tier \
     --volume /path/to/mariadb-persistence:/bitnami/mariadb \
     bitnami/mariadb:latest
   ```
@@ -123,7 +123,7 @@ version: '2'
 
   ```
   $ docker run -d --name redmine -p 80:3000 \
-    --net redmine \
+    --net redmine-tier \
     --volume /path/to/redmine-persistence:/bitnami/redmine \
   bitnami/redmine:latest
   ```


### PR DESCRIPTION
In order to be consistent, some sentences are changed by taking
Wordpress as a model.