### PR TITLE
replace the bundled common libraries with references to system packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,21 @@
-FROM gcr.io/stacksmith-images/minideb:jessie-r2
+FROM gcr.io/stacksmith-images/minideb:jessie-r4
 
 MAINTAINER Bitnami <containers@bitnami.com>
 
 ENV BITNAMI_APP_NAME=redmine \
-    BITNAMI_IMAGE_VERSION=3.3.1-r5 \
+    BITNAMI_IMAGE_VERSION=3.3.1-r6 \
     PATH=/opt/bitnami/ruby/bin:/opt/bitnami/mysql/bin:/opt/bitnami/git/bin:$PATH
 
+# System packages required
+RUN install_packages --no-install-recommends libc6 libssl1.0.0 zlib1g libreadline6 libncurses5 libtinfo5 libffi6 libxml2-dev zlib1g-dev libxslt1-dev libgmp-dev ghostscript imagemagick libmysqlclient18 libpq5 libstdc++6 libgcc1 libcurl3 libidn11 librtmp1 libssh2-1 libgssapi-krb5-2 libkrb5-3 libk5crypto3 libcomerr2 libldap-2.4-2 libgnutls-deb0-28 libhogweed2 libnettle4 libgmp10 libgcrypt20 libkrb5support0 libkeyutils1 libsasl2-2 libp11-kit0 libtasn1-6 libgpg-error0 libxml2 libxslt1.1 liblzma5 libmagickcore-6.q16-2 liblcms2-2 liblqr-1-0 libfftw3-double3 libfontconfig1 libfreetype6 libxext6 libx11-6 libbz2-1.0 libltdl7 libgomp1 libglib2.0-0 libexpat1 libpng12-0 libxcb1 libpcre3 libxau6 libxdmcp6
+
 # Additional modules required
-RUN bitnami-pkg install ruby-2.1.10-2 --checksum 2382f4f15ec657846a2090f5d05a8aa5cf7a77312d56b250653ef0bf00108a7f
-RUN bitnami-pkg install imagemagick-6.7.5-10-4 --checksum 02caf58e61a89db57ff3f62a412298fbaeff320cf32e196c9439959a197ed73d
-RUN bitnami-pkg install mysql-libraries-10.1.13-2 --checksum 1b61acd1d1f0f204d1e2b0b59411d21c2d5724edd4cdf1d7925de0819213a6ad
-RUN bitnami-pkg install mysql-client-10.1.19-0 --checksum fdbc292bedabeaf0148d66770b8aa0ab88012ce67b459d6ba2b46446c91bb79c
-RUN bitnami-pkg install git-2.6.1-2 --checksum edc04dc263211f3ffdc953cb96e5e3e76293dbf7a97a075b0a6f04e048b773dd
+RUN bitnami-pkg install ruby-2.1.10-3 --checksum e435ba6e622a94810bd320597e8bcb4c4e5866404b7fa41dc6addd2f6961d3e4
+RUN bitnami-pkg install mysql-client-10.1.19-1 --checksum 2d946c8ee3e2e845f68a5cf3751d6477d88af194d263842797fe50a44414a173
+RUN bitnami-pkg install git-2.10.1-1 --checksum 454e9eb6fb781c8d492f9937439dcdfc1a931959d948d4c70e79716d2ea51a2b
 
 # Install redmine
-RUN bitnami-pkg unpack redmine-3.3.1-4 --checksum b25b45a4a54956af7858839d41b8a09c6f84aabb35d0f261e9b9e1e10465c38d
+RUN bitnami-pkg unpack redmine-3.3.1-5 --checksum 9b0e798df05769a34342d25121842d9a1874e70a1c780778eb4a606ccfcfe843
 
 COPY rootfs /
 


### PR DESCRIPTION
Additional changes:
 - Updates the base image revision to `minideb-buildpack:jessie-r4`
 - Updated Redmine version to `3.3.1`

> **NOTE**: I closed https://github.com/bitnami/bitnami-docker-redmine/pull/53 by mistake. I fixed the conflicts with the branch.