### PR TITLE
Fix a bug with sed

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ if [[ ! -d /opt/bitnami/redmine/conf/ ]]; then
     echo 'Redmine::Utils::relative_url_root = "'${SUB_URI_PATH}'"' >> ${config2} 
 fi
 
-SUB_URI_PATH=$(echo ${SUB_URI_PATH} | sed -e 's|\/|\\/|g')
+SUB_URI_PATH=$(echo ${SUB_URI_PATH} | sed -e 's|/|\/|g')
 sed -i -e "s/\(relative_url_root\ \=\ \"\).*\(\"\)/\1${SUB_URI_PATH}\2/" ${config2}
 ```
 


### PR DESCRIPTION
**Fix a bug with sub-URI**

**Applicable issues**

Since separator is `|` escaping `/` in _regex_ and _replace_ sections of `sed` will not work as intended to.
